### PR TITLE
Fix scatterplot state load

### DIFF
--- a/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
+++ b/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
@@ -1,7 +1,7 @@
 <!-- scatterplot js files -->
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react/16.8.4/umd/react.production.min.js'></script>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.4/umd/react-dom.production.min.js'></script>
-<script src='https://unpkg.com/react-seda-scatterplot@1.0.3/umd/react-seda-scatterplot.min.js'></script>
+<script src='https://unpkg.com/react-seda-scatterplot@1.0.11/umd/react-seda-scatterplot.min.js'></script>
 <script src='https://unpkg.com/deepmerge@2.2.1/dist/umd.js'></script>
 <script  src="{{ "js/scatterplot/Scatterplot.js" | absURL }}"></script>
 {{ $a := "js/scatterplot/" }}

--- a/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
@@ -19,7 +19,7 @@ function Scatterplot(container, props) {
     title: {
       textStyle: {
         fontWeight: 'normal',
-        color: '#008acd'
+        color: '#000'
       }
     },
     visualMap: {
@@ -34,7 +34,7 @@ function Scatterplot(container, props) {
       }
     },
     tooltip: {
-      backgroundColor: 'rgba(50,50,50,0.5)',
+      backgroundColor: 'rgba(0,0,0,0.85)',
       axisPointer: {
         type: 'line',
         lineStyle: {
@@ -48,25 +48,8 @@ function Scatterplot(container, props) {
         }
       }
     },
-    dataZoom: {
-      dataBackgroundColor: '#efefff',
-      fillerColor: 'rgba(182,162,222,0.2)',
-      handleColor: '#008acd'
-    },
     grid: {
       borderColor: '#eee'
-    },
-    categoryAxis: {
-      axisLine: {
-        lineStyle: {
-          color: '#008acd'
-        }
-      },
-      splitLine: {
-        lineStyle: {
-          color: ['#eee']
-        }
-      }
     },
     valueAxis: {
       axisLine: {
@@ -81,39 +64,15 @@ function Scatterplot(container, props) {
         lineStyle: {
           color: ['#eee']
         }
+      },
+      nameTextStyle: {
+        color: '#000'
       }
-    },
-    timeline: {
-      lineStyle: {
-        color: '#008acd'
-      },
-      controlStyle: {
-        normal: {
-          color: '#008acd'
-        },
-        emphasis: {
-          color: '#008acd'
-        }
-      },
-      symbol: 'emptyCircle',
-      symbolSize: 3
     },
     line: {
       smooth: true,
       symbol: 'emptyCircle',
       symbolSize: 3
-    },
-    candlestick: {
-      itemStyle: {
-        normal: {
-          color: '#d87a80',
-          color0: '#2ec7c9',
-          lineStyle: {
-            color: '#d87a80',
-            color0: '#2ec7c9'
-          }
-        }
-      }
     },
     scatter: {
       symbol: 'circle',
@@ -123,54 +82,8 @@ function Scatterplot(container, props) {
         borderOpacity:0.5,
       }
     },
-    map: {
-      label: {
-        normal: {
-          textStyle: {
-            color: '#d87a80'
-          }
-        }
-      },
-      itemStyle: {
-        normal: {
-          borderColor: '#eee',
-          areaColor: '#ddd'
-        },
-        emphasis: {
-          areaColor: '#fe994e'
-        }
-      }
-    },
     graph: {
       color: colorPalette
-    },
-    gauge: {
-      axisLine: {
-        lineStyle: {
-          color: [
-            [0.2, '#2ec7c9'],
-            [0.8, '#5ab1ef'],
-            [1, '#d87a80']
-          ],
-          width: 10
-        }
-      },
-      axisTick: {
-        splitNumber: 10,
-        length: 15,
-        lineStyle: {
-          color: 'auto'
-        }
-      },
-      splitLine: {
-        length: 22,
-        lineStyle: {
-          color: 'auto'
-        }
-      },
-      pointer: {
-        width: 5
-      }
     }
   };
   

--- a/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
@@ -61,12 +61,20 @@ function Scatterplot(container, props) {
         show: false,
       },
       splitLine: {
-        lineStyle: {
-          color: ['#eee']
-        }
+        show: false,
       },
       nameTextStyle: {
-        color: '#000'
+        color: '#000',
+        fontSize: 12,
+        fontWeight: 'normal'
+      },
+      nameLocation: 'middle',
+      nameGap: 32,
+      axisLabel: {
+        inside: false,
+        textVerticalAlign: 'middle',
+        color: '#999',
+        fontSize: 12,
       }
     },
     line: {
@@ -100,20 +108,10 @@ function Scatterplot(container, props) {
         },
         yAxis: { 
           position: 'right',
-          nameLocation: 'middle',
-          nameGap: 32,
-          nameTextStyle: {
-            fontSize: 12,
-            fontWeight: 'normal'
-          },
           splitLine: {
             show: false,
           },
           axisLabel: {
-            inside: false,
-            textVerticalAlign: 'middle',
-            color: '#999',
-            fontSize: 12,
             align: 'right',
           }
         },
@@ -123,12 +121,6 @@ function Scatterplot(container, props) {
             fontSize: 12,
             fontWeight: 'normal'
           },
-          axisLabel: {
-            inside: false,
-            textVerticalAlign: 'middle',
-            color: '#999',
-            fontSize: 12,
-          }
         },
         tooltip: {
           trigger: 'item'

--- a/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
@@ -2,94 +2,256 @@
  * Helper class for easier scatterplot updates
  */
 function Scatterplot(container, props) {
-
+  
   var _self = this;
   var _ready = false;
   var _handlers = {};
 
+  var colorPalette = [
+    '#2ec7c9', '#b6a2de', '#5ab1ef', '#ffb980', '#d87a80',
+    '#8d98b3', '#e5cf0d', '#97b552', '#95706d', '#dc69aa',
+    '#07a2a4', '#9a7fd1', '#588dd5', '#f5994e', '#c05050',
+    '#59678c', '#c9ab00', '#7eb00a', '#6f5553', '#c14089'
+  ];
+  
+  var theme = {
+    color: colorPalette,
+    title: {
+      textStyle: {
+        fontWeight: 'normal',
+        color: '#008acd'
+      }
+    },
+    visualMap: {
+      itemWidth: 15,
+      color: ['#5ab1ef', '#e0ffff']
+    },
+    toolbox: {
+      iconStyle: {
+        normal: {
+          borderColor: colorPalette[0]
+        }
+      }
+    },
+    tooltip: {
+      backgroundColor: 'rgba(50,50,50,0.5)',
+      axisPointer: {
+        type: 'line',
+        lineStyle: {
+          color: '#008acd'
+        },
+        crossStyle: {
+          color: '#008acd'
+        },
+        shadowStyle: {
+          color: 'rgba(200,200,200,0.2)'
+        }
+      }
+    },
+    dataZoom: {
+      dataBackgroundColor: '#efefff',
+      fillerColor: 'rgba(182,162,222,0.2)',
+      handleColor: '#008acd'
+    },
+    grid: {
+      borderColor: '#eee'
+    },
+    categoryAxis: {
+      axisLine: {
+        lineStyle: {
+          color: '#008acd'
+        }
+      },
+      splitLine: {
+        lineStyle: {
+          color: ['#eee']
+        }
+      }
+    },
+    valueAxis: {
+      axisLine: {
+        lineStyle: {
+          color: '#008acd'
+        }
+      },
+      splitArea: {
+        show: false,
+      },
+      splitLine: {
+        lineStyle: {
+          color: ['#eee']
+        }
+      }
+    },
+    timeline: {
+      lineStyle: {
+        color: '#008acd'
+      },
+      controlStyle: {
+        normal: {
+          color: '#008acd'
+        },
+        emphasis: {
+          color: '#008acd'
+        }
+      },
+      symbol: 'emptyCircle',
+      symbolSize: 3
+    },
+    line: {
+      smooth: true,
+      symbol: 'emptyCircle',
+      symbolSize: 3
+    },
+    candlestick: {
+      itemStyle: {
+        normal: {
+          color: '#d87a80',
+          color0: '#2ec7c9',
+          lineStyle: {
+            color: '#d87a80',
+            color0: '#2ec7c9'
+          }
+        }
+      }
+    },
+    scatter: {
+      symbol: 'circle',
+      itemStyle: {
+        borderWidth: 1,
+        borderColor: 'rgba(0,0,0,0.5)',
+        borderOpacity:0.5,
+      }
+    },
+    map: {
+      label: {
+        normal: {
+          textStyle: {
+            color: '#d87a80'
+          }
+        }
+      },
+      itemStyle: {
+        normal: {
+          borderColor: '#eee',
+          areaColor: '#ddd'
+        },
+        emphasis: {
+          areaColor: '#fe994e'
+        }
+      }
+    },
+    graph: {
+      color: colorPalette
+    },
+    gauge: {
+      axisLine: {
+        lineStyle: {
+          color: [
+            [0.2, '#2ec7c9'],
+            [0.8, '#5ab1ef'],
+            [1, '#d87a80']
+          ],
+          width: 10
+        }
+      },
+      axisTick: {
+        splitNumber: 10,
+        length: 15,
+        lineStyle: {
+          color: 'auto'
+        }
+      },
+      splitLine: {
+        length: 22,
+        lineStyle: {
+          color: 'auto'
+        }
+      },
+      pointer: {
+        width: 5
+      }
+    }
+  };
+  
   this.states = {
     // default state shared by all scatterplots
     // https://ecomfe.github.io/echarts-doc/public/en/option.html
     base: {
-      grid: {
-        top: 24,
-        bottom: 48,
-        left: 24,
-        right: 48,
-      },
-      yAxis: {
-        position: 'right',
-        nameLocation: 'middle',
-        nameGap: 32,
-        nameTextStyle: {
-          fontSize: 12,
-          fontWeight: 'normal'
+      options: {
+        grid: {
+          top: 24,
+          bottom: 48,
+          left: 24,
+          right: 48,
         },
-        splitLine: {
-          show: false,
+        yAxis: { 
+          position: 'right',
+          nameLocation: 'middle',
+          nameGap: 32,
+          nameTextStyle: {
+            fontSize: 12,
+            fontWeight: 'normal'
+          },
+          splitLine: {
+            show: false,
+          },
+          axisLabel: {
+            inside: false,
+            textVerticalAlign: 'middle',
+            color: '#999',
+            fontSize: 12,
+            align: 'right',
+          }
         },
-        axisLabel: {
-          inside: false,
-          textVerticalAlign: 'middle',
-          color: '#999',
-          fontSize: 12,
-          align: 'right',
-        }
-      },
-      xAxis: {
-        nameGap: 32,
-        nameTextStyle: {
-          fontSize: 12,
-          fontWeight: 'normal'
+        xAxis: {
+          nameGap: 32,
+          nameTextStyle: {
+            fontSize: 12,
+            fontWeight: 'normal'
+          },
+          axisLabel: {
+            inside: false,
+            textVerticalAlign: 'middle',
+            color: '#999',
+            fontSize: 12,
+          }
         },
-        axisLabel: {
-          inside: false,
-          textVerticalAlign: 'middle',
-          color: '#999',
-          fontSize: 12,
-        }
-      },
-      series: [{
-        type: 'scatter',
-        itemStyle: {
-          color: '#ccc',
-          borderColor: 'rgba(0,0,0,0.5)',
-          borderWidth: 1
+        tooltip: {
+          trigger: 'item'
         },
-      }],
-      tooltip: {
-        trigger: 'item'
-      },
+      }
     }
   }
-
+  
   // add a ref prop to get a reference to the react component instance
-  this.props = Object.assign(
-    (props || {}),
-    {
+  this.props = Object.assign( 
+    (props || {}), 
+    { 
       prefix: 'districts',
-      options: this.states.base,
+      options: this.states.base.options,
       endpoint: 'https://d2fypeb6f974r1.cloudfront.net/dev/scatterplot/',
-      ref: function(ref) {
-        _self.component = ref;
+      ref: function(ref) { 
+        _self.component = ref; 
       },
       onReady: function(echartInstance) {
         _ready = true;
         _self.trigger('ready', [_self])
-      }
+      },
+      theme: theme
     }
   );
-
+  
   /**
    * Triggers an event with `eventName` and runs all handlers
    */
   this.trigger = function(eventName, data) {
-    _handlers[eventName] &&
+    _handlers[eventName] && 
     _handlers[eventName].forEach(function(h) {
       h.apply(null, data)
     })
   }
-
+  
   /**
    * Registers an event handler with the associated eventName
    * If it's a ready handler and everything is ready, run immediately.
@@ -103,7 +265,7 @@ function Scatterplot(container, props) {
       handler(_self.component, _self.component.echart)
     }
   }
-
+  
   /**
    * Set a state generator for the scatterplot
    */
@@ -114,9 +276,13 @@ function Scatterplot(container, props) {
   /**
    * Load a state for the scatterplot
    */
-  this.loadState = function(stateName, options) {
-    console.log('loadstate ' + stateName);
-    this.component.echart.setOption(this.getState(stateName), options)
+  this.loadState = function(stateName, options = {}) {
+    // this.component.echart.setOption(this.getState(stateName), options)
+    const newState = this.getState(stateName);
+    if (options.hasOwnProperty('notMerge')) {
+      newState['notMerge'] = options.notMerge
+    }
+    this.setProps(newState)
   }
 
   /**
@@ -136,7 +302,7 @@ function Scatterplot(container, props) {
   this.getDataSeries = function() {
     var options = this.component.getOption();
     if (options.series && options.series.length) {
-      return options.series.find(s => s.id === 'scatter')
+      return options.series.find(s => s.id === 'base')
     }
     return null;
   }
@@ -145,20 +311,26 @@ function Scatterplot(container, props) {
    * Set an object of props for the react component
    */
   this.setProps = function(props) {
-    const oldProps = Object.assign({}, {...this.component.props });
-    Object.keys(props).forEach(
-      function(p) {
-        _self.component.props[p] = props[p];
-      }
-    );
-    this.component.componentDidUpdate(oldProps);
+    this.props = {
+      ...this.props,
+      ...props
+    }
+    this.render();
   }
 
-  // render the component
-  ReactDOM.render(
-    React.createElement(sedaScatterplot, this.props, null),
-    container
-  );
+  /**
+   * Render the component with props
+   */
+  this.render = function() {
+    // render the component
+    ReactDOM.render(
+      React.createElement(sedaScatterplot, this.props, null),
+      container
+    );
+  }
+  
+  this.render()
+
 }
 
 /**
@@ -188,7 +360,7 @@ Scatterplot.prototype.getSeriesDataForIds = function(values, ids) {
 
 /** Returns an array of values that fall within the range on the provided axis */
 Scatterplot.prototype.getSeriesDataInRange = function(values, axis, range) {
-  var index = axis === 'x' ? 0 :
+  var index = axis === 'x' ? 0 : 
     axis === 'y' ? 1 : 2;
   return values.filter(function(v) {
     return v[index] > range.min && v[index] < range.max;

--- a/themes/base-hugo-theme/static/js/scatterplot/article1.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/article1.js
@@ -361,7 +361,7 @@ scatterplot.loadState('state1');
         }, 10000)
         setTimeout(() => {
           scatterplot.loadState('state2')
-        }, 5000)
+        }, 15000)
         // end testing.
 
         var userScrolled = false;

--- a/themes/base-hugo-theme/static/js/scatterplot/article1.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/article1.js
@@ -5,13 +5,6 @@
 
 /** State 1: Show white scores on x axis and black scores on y axis */
 var state1 = function(scatterplot) {
-  scatterplot.setProps({
-    xVar: 'w_avg',
-    yVar: 'b_avg',
-    zVar: 'sz',
-  });
-  // get current echart options
-  const options = scatterplot.component.getOption();
   // this state is created from the base
   const base = scatterplot.getState('base');
   const baseOverrides = {
@@ -84,7 +77,12 @@ var state1 = function(scatterplot) {
       }
     }]
   }
-  return deepmerge.all([base, baseOverrides ]);
+  return {
+    xVar: 'w_avg',
+    yVar: 'b_avg',
+    zVar: 'sz',
+    options: deepmerge.all([base.options, baseOverrides ])
+  }
 }
 
 /** State 2: Highlight largest 25 districts  */
@@ -94,21 +92,23 @@ var state2 = function(scatterplot) {
   var dataSeries = scatterplot.getDataSeries();
   dataSeries['itemStyle'] = Object.assign(dataSeries['itemStyle'], { opacity: 0.2 })
   var top100 = scatterplot.getSeriesDataBySize(dataSeries.data, 10)
-  return deepmerge(base, {
-    series: [
-      dataSeries,
-      {
-        type: 'scatter',
-        data: top100,
-        symbolSize: dataSeries.symbolSize,
-        itemStyle: {
-          borderWidth: 1,
-          borderColor: 'rgba(0,0,0,1)',
-          color: 'rgba(255,0,0,0.25)'
+  return {
+    options: deepmerge(base.options, {
+      series: [
+        dataSeries,
+        {
+          type: 'scatter',
+          data: top100,
+          symbolSize: dataSeries.symbolSize,
+          itemStyle: {
+            borderWidth: 1,
+            borderColor: 'rgba(0,0,0,1)',
+            color: 'rgba(255,0,0,0.25)'
+          }
         }
-      }
-    ]
-  })
+      ]
+    })
+  }
 };
 
 /** State 3: Highlight locations (Detroit, Gwinet, Washington) */
@@ -117,31 +117,28 @@ var state3 = function(scatterplot) {
   var base = scatterplot.getState('state2');
   var dataSeries = scatterplot.getDataSeries();
   var highlightedValues = scatterplot.getSeriesDataForIds(dataSeries.data, highlightIds);
-  return deepmerge(base, {
-    series: [
-      base.series[0],
-      base.series[1],
-      {
-        type: 'scatter',
-        data: highlightedValues,
-        symbolSize: dataSeries.symbolSize,
-        itemStyle: {
-          borderWidth: 2,
-          borderColor: 'rgba(0,0,0,1)',
-          color: 'rgba(255,255,0,0.5)'
+  return {
+    options: deepmerge(base.options, {
+      series: [
+        base.series[0],
+        base.series[1],
+        {
+          type: 'scatter',
+          data: highlightedValues,
+          symbolSize: dataSeries.symbolSize,
+          itemStyle: {
+            borderWidth: 2,
+            borderColor: 'rgba(0,0,0,1)',
+            color: 'rgba(255,255,0,0.5)'
+          }
         }
-      }
-    ]
-  })
+      ]
+    })
+  }
 };
 
 /** State 4: Load new variables to show White/Black SES Gap and Achievement Gap */
 var state4 = function(scatterplot) {
-  scatterplot.setProps({
-    xVar: 'wb_ses',
-    yVar: 'wb_avg',
-    zVar: 'sz',
-  });
   // get current echart options
   const options = scatterplot.component.getOption();
   // this state is created from the base
@@ -191,7 +188,12 @@ var state4 = function(scatterplot) {
       }
     }]
   }
-  return deepmerge.all([ base, baseOverrides ]);
+  return {
+    xVar: 'wb_ses',
+    yVar: 'wb_avg',
+    zVar: 'sz',
+    options: deepmerge.all([ base.options, baseOverrides ])
+  }
 }
 
 /** State 5: Highlight largest districts */
@@ -248,7 +250,7 @@ scatterplot.addState('state7', state9);
 scatterplot.addState('state8', state10);
 
 // load the first state
-scatterplot.loadState('state1', { notMerge: true });
+scatterplot.loadState('state1');
 
 // when the component is ready, trigger the state change as desired
 // scatterplot.on('ready', function(scatterplot) {
@@ -353,13 +355,13 @@ scatterplot.loadState('state1', { notMerge: true });
         // @lane: testing here to isolate the plot from my scroll logic.
         setTimeout(() => {
           scatterplot.loadState('state2');
-        }, 2000)
+        }, 5000)
         setTimeout(() => {
           scatterplot.loadState('state1', { notMerge: true })
-        }, 4000)
+        }, 10000)
         setTimeout(() => {
           scatterplot.loadState('state2')
-        }, 6000)
+        }, 5000)
         // end testing.
 
         var userScrolled = false;


### PR DESCRIPTION
Had to change up how states are created a bit to get this working.  Prior to this update, each state would return only an echarts options object.  With this update, each state should return an object containing [scatterplot component properties](https://github.com/Hyperobjekt/react-seda-scatterplot#props).

This allows for the changing of `xVar` and `yVar` between states.

I also added a base theme in `Scatterplot.js` that can be modified to change scatterplot styles.