### PR TITLE
Highlighting Demo

### DIFF
--- a/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
+++ b/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
@@ -1,7 +1,7 @@
 <!-- scatterplot js files -->
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react/16.8.4/umd/react.production.min.js'></script>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.4/umd/react-dom.production.min.js'></script>
-<script src='https://unpkg.com/react-seda-scatterplot@1.0.11/umd/react-seda-scatterplot.min.js'></script>
+<script src='https://unpkg.com/react-seda-scatterplot@1.0.18/umd/react-seda-scatterplot.min.js'></script>
 <script src='https://unpkg.com/deepmerge@2.2.1/dist/umd.js'></script>
 <script  src="{{ "js/scatterplot/Scatterplot.js" | absURL }}"></script>
 {{ $a := "js/scatterplot/" }}

--- a/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
@@ -147,7 +147,20 @@ function Scatterplot(container, props) {
           zlevel: 102,
         },
         tooltip: {
-          trigger: 'item'
+          trigger: 'item',
+          formatter: function(item) {
+            const data = _self.data[_self.props.prefix];
+            const itemName = 
+              data && 
+              data.name &&
+              data.name[item.value[3]] ?
+              data.name[item.value[3]] : 'Unavailable'
+            console.log(data);
+            return itemName + '<br />'
+              + 'X: ' + item.value[0] + '\n'
+              + 'Y: ' + item.value[1]
+              
+          }
         },
       }
     }
@@ -160,12 +173,20 @@ function Scatterplot(container, props) {
       prefix: 'districts',
       options: this.states.base.options,
       endpoint: 'https://d2fypeb6f974r1.cloudfront.net/dev/scatterplot/',
+      baseVars: {
+        'counties': ['id', 'name', 'lat', 'lon', 'all_avg', 'all_ses', 'sz' ],
+        'districts': ['id', 'name', 'lat', 'lon', 'all_avg', 'all_ses', 'sz' ],
+        'schools': ['id', 'name', 'lat', 'lon', 'all_avg', 'frl_pct', 'sz' ]
+      },
       ref: function(ref) {
         _self.component = ref;
       },
       onReady: function(echartInstance) {
         _ready = true;
         _self.trigger('ready', [_self])
+      },
+      onDataLoaded: function(data) {
+        _self.data = data
       },
       theme: theme
     }

--- a/themes/base-hugo-theme/static/js/scatterplot/article1.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/article1.js
@@ -85,6 +85,7 @@ var state1 = function(scatterplot) {
     xVar: 'w_avg',
     yVar: 'b_avg',
     zVar: 'sz',
+    highlighted: [],
     options: deepmerge.all([base.options, baseOverrides ])
   }
 }
@@ -97,6 +98,7 @@ var state2 = function(scatterplot) {
   dataSeries['itemStyle'] = Object.assign(dataSeries['itemStyle'], { opacity: 0.2 })
   var top100 = scatterplot.getSeriesDataBySize(dataSeries.data, 100)
   return {
+    highlighted: [],
     options: deepmerge(base.options, {
       title: {
         subtext: '100 Largest U.S. School Districts 2009-2016'
@@ -120,25 +122,22 @@ var state2 = function(scatterplot) {
 
 /** State 3: Highlight locations (Detroit, Gwinet, Washington) */
 var state3 = function(scatterplot) {
-  var highlightIds = [ '0641580', '2612000', '1302550' ]
-  var highlightLabels = [ 'Detroit, MI', 'Gwinnet County, GA', 'Washington, D.C.'];
+  var highlight = {
+    '0641580': 'Washington, D.C.', 
+    '2612000': 'Detroit, MI', 
+    '1302550': 'Gwinnet County, GA'
+  }
   var base = scatterplot.getState('state2');
   var dataSeries = scatterplot.getDataSeries();
-  var highlightedValues = scatterplot.getSeriesDataForIds(dataSeries.data, highlightIds);
-  console.log(highlightedValues);
-  // highlightedValues[0][1] = 'Detroit, MI';
-  // highlightedValues[1][1] = 'Gwinnet County, GA';
-  // console.log(highlightedValues);
   return {
+    highlighted: Object.keys(highlight),
     options: deepmerge(base.options, {
       series: [
         // base.series[0],
         // base.series[1],
         dataSeries,
         {
-          type: 'scatter',
-          data: highlightedValues,
-          symbolSize: dataSeries.symbolSize,
+          id: 'highlighted',
           itemStyle: {
             borderWidth: 2,
             borderColor: 'rgba(0,0,0,1)',
@@ -151,7 +150,10 @@ var state3 = function(scatterplot) {
             borderColor: '#042965',
             padding: [6, 8],
             borderRadius: 3,
-            color: '#dc69aa'
+            color: '#dc69aa',
+            formatter: function(item) {
+              return highlight[item.value[3]]
+            }
           }
         }
       ]
@@ -228,6 +230,7 @@ var state4 = function(scatterplot) {
     }]
   }
   return {
+    highlighted: [],
     xVar: 'wb_ses',
     yVar: 'wb_avg',
     zVar: 'sz',


### PR DESCRIPTION
# In this update:

- the state can return a `highlighted` property in the returned state to highlight circles that correspond to specific identifiers (See [Line 133 of article1.js](https://github.com/Hyperobjekt/seda-site/blob/0e6f01b5d3e989808252caf2d2e7c4ebcb97099b/themes/base-hugo-theme/static/js/scatterplot/article1.js#L133))
  - any circles corresponding to the identifiers in the `highlighted` property are styled with an echarts object with `id: 'highlighted'` (See [Line 140 of article1.js](https://github.com/Hyperobjekt/seda-site/blob/0e6f01b5d3e989808252caf2d2e7c4ebcb97099b/themes/base-hugo-theme/static/js/scatterplot/article1.js#L140)) 
> Note: a `selected` property can also be returned from the state generator to highlight an additional set of identifiers
- you can access any of the scatterplot data through the `.data` attribute on the `scatterplot` instance passed to each state generator.  See [Line 151 of Scatterplot.js](https://github.com/Hyperobjekt/seda-site/blob/0e6f01b5d3e989808252caf2d2e7c4ebcb97099b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js#L151) to see how this is used to grab the place name for tooltips.
