### PR TITLE
Use CSV data as source

### DIFF
--- a/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
+++ b/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
@@ -1,10 +1,10 @@
 <!-- scatterplot js files -->
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react/16.8.4/umd/react.production.min.js'></script>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.4/umd/react-dom.production.min.js'></script>
-<script src='https://unpkg.com/react-seda-scatterplot@1.0.18/umd/react-seda-scatterplot.min.js'></script>
+<script src='https://unpkg.com/react-seda-scatterplot@1.3.2/umd/react-seda-scatterplot.min.js'></script>
 <script src='https://unpkg.com/deepmerge@2.2.1/dist/umd.js'></script>
 <script src='https://unpkg.com/papaparse@4.6.3/papaparse.min.js'></script>
-<script src='https://unpkg.com/react-seda-search@1.0.4/umd/react-seda-search.min.js'></script>
+<script src='https://unpkg.com/react-seda-search@1.0.5/umd/react-seda-search.min.js'></script>
 <script  src="{{ "js/scatterplot/Scatterplot.js" | absURL }}"></script>
 <!-- Load article states -->
 {{ $a := "js/scatterplot/" }}

--- a/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/Scatterplot.js
@@ -183,11 +183,12 @@ function Scatterplot(container, props) {
       prefix: 'districts',
       options: this.states.base.options,
       endpoint: 'https://d2fypeb6f974r1.cloudfront.net/dev/scatterplot/',
-      baseVars: {
-        'counties': ['id', 'name', 'lat', 'lon', 'all_avg', 'all_ses', 'sz' ],
-        'districts': ['id', 'name', 'lat', 'lon', 'all_avg', 'all_ses', 'sz' ],
-        'schools': ['id', 'name', 'lat', 'lon', 'all_avg', 'frl_pct', 'sz' ]
+      metaVars: {
+        'counties': ['id', 'name', 'lat', 'lon', 'all_sz' ],
+        'districts': ['id', 'name', 'lat', 'lon', 'all_sz' ],
+        'schools': ['id', 'name', 'lat', 'lon', 'all_sz' ]
       },
+      data: {},
       ref: function(ref) {
         _self.component = ref;
       },
@@ -195,8 +196,12 @@ function Scatterplot(container, props) {
         _ready = true;
         _self.trigger('ready', [_self])
       },
-      onDataLoaded: function(data) {
-        _self.data = data
+      onData: function(data, region) {
+        let currData = ((_self.data && _self.data[region]) || {})
+        const newData = {}
+        newData[region] = Object.assign(currData, data)
+        _self.data = Object.assign((_self.data || {}), newData)
+        _self.setProps({data:_self.data})
       },
       theme: theme
     }
@@ -257,6 +262,10 @@ function Scatterplot(container, props) {
     } else {
       throw new Error('no state found for ' + stateName)
     }
+  }
+
+  this.getScatterplotSeries = function (xVar, yVar, zVar, ids) {
+
   }
 
   this.getDataSeries = function() {

--- a/themes/base-hugo-theme/static/js/scatterplot/article1.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/article1.js
@@ -27,6 +27,18 @@ function sliceMost(arr, size) {
 }
 
 /**
+ * Pulls the largest IDs from an object containing id: value pairs
+ * @param {object} objData id: value pairs, (eg. { "010001": 4.5, "010002", 10, ...})
+ * @param {number} num number of ids to return (e.g. 1)
+ * @returns {array} array of ids with the largest values (e.g. [ "010002" ])
+ */
+function getLargestIds(objData, num) {
+  return Object.keys(objData).sort(function(a, b) {
+    return objData[b] - objData[a];
+  }).slice(0, num);
+}
+
+/**
  * Sort provided array by segregation stats
  * @param Array data
  * @returns Array returnArr
@@ -90,7 +102,6 @@ xhr.send(null);
 /** State 1: Show white scores on x axis and black scores on y axis */
 var state1 = function(scatterplot) {
   // this state is created from the base
-  const base = scatterplot.getState('base');
   // Set up array of district IDs and names for building search series.
   if (names.length <= 0 &&
     scatterplot && 
@@ -191,9 +202,8 @@ var state1 = function(scatterplot) {
               coord: [4, 0],
               symbol: 'none'
             },
-          ]
-        ]
-      }
+          ]]
+        }
       },
       {
         type: 'scatter',
@@ -228,9 +238,9 @@ var state1 = function(scatterplot) {
   return {
     xVar: 'w_avg',
     yVar: 'b_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     highlighted: [],
-    options: deepmerge.all([base.options, baseOverrides ])
+    options: baseOverrides
   }
 }
 
@@ -247,6 +257,7 @@ var state2 = function(scatterplot) {
   }
   // console.log(top100);
   return {
+    selected: [],
     highlighted: [],
     options: deepmerge(base.options, {
       title: {
@@ -322,7 +333,7 @@ var state3 = function(scatterplot) {
   var base = scatterplot.getState('base');
   var dataSeries = scatterplot.getDataSeries();
   dataSeries['itemStyle'] = Object.assign(dataSeries['itemStyle'], { opacity: 0.2 })
-  var top100 = scatterplot.getSeriesDataBySize(dataSeries.data, 100)
+  var top100 = getLargestIds(scatterplot.data['districts']['all_sz'], 100)
   var searchSeries = [];
   if (scatterplot && scatterplot.data) {
     searchSeries = scatterplot.getSeriesDataForIds(dataSeries.data, searchItemIDs);
@@ -330,9 +341,10 @@ var state3 = function(scatterplot) {
   return {
     xVar: 'w_avg',
     yVar: 'b_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     highlighted: Object.keys(highlight),
-    options: deepmerge(base.options, {
+    selected: top100,
+    options: {
       title: {
         text: 'White and Black Students\' Average Performance',
         subtext: 'U.S. School Districts 2009-2016'
@@ -352,18 +364,17 @@ var state3 = function(scatterplot) {
         name: 'White Average Performance',
       },
       series: [
-        // base.series[0],
-        // base.series[1],
-        dataSeries,
+        { id: 'base' },
         {
+          id: 'selected',
           type: 'scatter',
-          data: top100,
           symbolSize: dataSeries.symbolSize,
           itemStyle: {
             borderWidth: 1,
             borderColor: 'rgba(0,0,0,1)',
             color: '#b6a2de' // 'rgba(255,0,0,0.25)'
-          }
+          },
+          z: 2
         },
         {
           id: 'highlighted',
@@ -483,7 +494,7 @@ var state3 = function(scatterplot) {
           ]}
         }
       ]
-    })
+    }
   }
 };
 
@@ -602,10 +613,11 @@ var state4 = function(scatterplot) {
   ]
   }
   return {
+    selected: [],
     highlighted: [],
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -963,7 +975,7 @@ var state8 = function(scatterplot) {
     highlighted: Object.keys(highlight),
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -1137,7 +1149,7 @@ var state9 = function(scatterplot) {
     highlighted: [],
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -1295,7 +1307,7 @@ var state10 = function(scatterplot) {
     highlighted: Object.keys(highlight),
     xVar: 'wb_pov',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }

--- a/themes/base-hugo-theme/static/js/scatterplot/article2.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/article2.js
@@ -32,6 +32,7 @@ function sliceMost(arr, size) {
  * @returns Array returnArr
  */
 function sortDataBySeg(data) {
+    return data
   // console.log('sortDataBySeg()');
   // console.log(data);
   // Loop through the data.
@@ -225,7 +226,7 @@ var state1 = function(scatterplot) {
   return {
     xVar: 'all_ses',
     yVar: 'all_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     highlighted: [],
     options: deepmerge.all([base.options, baseOverrides ])
   }
@@ -327,7 +328,7 @@ var state3 = function(scatterplot) {
   return {
     xVar: 'w_avg',
     yVar: 'b_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     highlighted: Object.keys(highlight),
     options: deepmerge(base.options, {
       title: {
@@ -600,7 +601,7 @@ var state4 = function(scatterplot) {
     highlighted: [],
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -958,7 +959,7 @@ var state8 = function(scatterplot) {
     highlighted: Object.keys(highlight),
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -1132,7 +1133,7 @@ var state9 = function(scatterplot) {
     highlighted: [],
     xVar: 'wb_ses',
     yVar: 'wb_avg',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }
@@ -1248,7 +1249,7 @@ var state10 = function(scatterplot) {
     highlighted: [], // Object.keys(highlight),
     xVar: 'all_avg',
     yVar: 'all_grd',
-    zVar: 'sz',
+    zVar: 'all_sz',
     options: deepmerge.all([ base.options, baseOverrides ])
   }
 }

--- a/themes/base-hugo-theme/static/js/scatterplot/plot.js
+++ b/themes/base-hugo-theme/static/js/scatterplot/plot.js
@@ -50,7 +50,7 @@
           this.render(refProps);
         },
         update: function() {
-            //  console.log('update');
+             console.log('update');
             var activeWrappers = $.grep(plot.wrappers, function(el) {
                 // Get top and bottom y coords of wrapper
                 plot.top = (plot.scatterplot).offset().top;


### PR DESCRIPTION
Changes:
- Updates scatterplot version to 1.3.2 (newer data, more variables, `sz` is now `all_sz`)
- Uses the `selected` prop to highlight the top100

> Note: Use `scatterplot.data` to retrieve data values instead of `scatterplot.getDataSeries` if data is required but there is a variable change between states.  `scatterplot.getDataSeries` returns the data series for the previous state.