### PR TITLE
update react-seda-search to ie11 compatible

### DIFF
--- a/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
+++ b/themes/base-hugo-theme/layouts/partials/scatterplot-scripts.html
@@ -4,7 +4,7 @@
 <script src='https://unpkg.com/react-seda-scatterplot@1.3.2/umd/react-seda-scatterplot.min.js'></script>
 <script src='https://unpkg.com/deepmerge@2.2.1/dist/umd.js'></script>
 <script src='https://unpkg.com/papaparse@4.6.3/papaparse.min.js'></script>
-<script src='https://unpkg.com/react-seda-search@1.0.9/umd/react-seda-search.min.js'></script>
+<script src='https://unpkg.com/react-seda-search@1.0.10/umd/react-seda-search.min.js'></script>
 <script  src="{{ "js/scatterplot/Scatterplot.js" | absURL }}"></script>
 <!-- Load article states -->
 {{ $a := "js/scatterplot/" }}


### PR DESCRIPTION
added babel config to `react-seda-search@1.0.10`.  this PR updates the script to point at the new version. 