### PR TITLE
Discovery Updates

### DIFF
--- a/themes/base-hugo-theme/assets/js/src/nam-discovery/index.js
+++ b/themes/base-hugo-theme/assets/js/src/nam-discovery/index.js
@@ -268,13 +268,13 @@ Seda.NamDiscovery = (function (Seda) {
           fontFamily: 'SharpGrotesk-Medium20'
         },
         textAlign: window.innerWidth > 767 ? 'center' : 'left',
-        left: window.innerWidth > 767 ? "50%" : 0
+        left: window.innerWidth > 767 ? "37%" : 0
       },
       grid: {
         left: window.innerWidth > 767 ? 100 : 47,
-        top: window.innerWidth > 1150 ? 180 : 175,
-        right: window.innerWidth > 1150 ? 375 : window.innerWidth > 767 ? 200 : 1,
-        bottom: window.innerWidth > 767 ? 50 : 100
+        top: window.innerWidth > 1150 ? 90 : 90,
+        right: window.innerWidth > 1150 ? 400 : window.innerWidth > 767 ? 285 : 1,
+        bottom: window.innerWidth > 1150 ? 140 : window.innerWidth > 767 ? 170 : 200
       },
       tooltip: {
         className: 'nam-tooltip',
@@ -297,9 +297,9 @@ Seda.NamDiscovery = (function (Seda) {
       },
       legend: {
         orient: "horizontal",
-        width: window.innerWidth > 1150 ? 800 : 400,
+        width: window.innerWidth > 1150 ? 800 : 500,
         left: window.innerWidth > 767 ? 95 : 0,
-        top: window.innerWidth > 767 ? 90 : 60,
+        bottom: window.innerWidth > 767 ? 0 : 0,
         show: true,
         itemGap: 16,
         textStyle: {
@@ -312,6 +312,7 @@ Seda.NamDiscovery = (function (Seda) {
         nameGap: window.innerWidth > 767 ? 32 : 55,
         nameTextStyle: {
           lineHeight: 18,
+          fontSize: 13,
           align: "center"
         },
         axisLine: {
@@ -330,6 +331,9 @@ Seda.NamDiscovery = (function (Seda) {
         name: Y_LABEL,
         nameLocation: "center",
         nameGap: window.innerWidth > 767 ? 80 : 35,
+        nameTextStyle: {
+          fontSize: 13
+        },
         min: 0.6,
         max: 1.6,
         axisLine: {

--- a/themes/base-hugo-theme/assets/scss/discovery.scss
+++ b/themes/base-hugo-theme/assets/scss/discovery.scss
@@ -1,13 +1,15 @@
 .visual {
     position: relative;
-    height: 700px;
+    height: 600px;
 }
 
 .visual__search {
     position: absolute;
     right: 0;
-    top: 180px;
-    width: 317px;
+    top: 90px;
+    background: #F6FBFF;
+    padding: 31px;
+    width: 360px;
     ul li, ul li p  {
         font-size: 1.5rem  !important;
     }
@@ -15,8 +17,8 @@
 
 @media screen and (max-width: 1150px) {
     .visual__search {
-      width: 180px;
-      top: 110px;
+      width: 270px;
+      padding: 15px;
     }
 }
 .visual__search-drawer > button {
@@ -143,7 +145,7 @@
     position: relative; 
     left: 50%; 
     transform: translateX(-50%);
-    max-width: 1320px;
+    max-width: 1190px;
 }
 @media screen and (max-width: 767px) {
     .visual__canvas {


### PR DESCRIPTION
Handles the following outlined in the 4.1 Discovery Updates issue

- Widen text column slightly
- Set slightly narrower max-width on the visualization
- Implement blue background box for search/selection panel
- Move legend to beneath the chart
- Increase size of axis labels

A note: I noticed that the chart title also got moved a bit in the designs, centering over the chart grid now as opposed to over the whole page. This looks reasonable in the context of the design, where the chart is still in the middle of two paragraphs, but the current state of the site places the chart at the top of the discovery. This makes the title look a bit misaligned – happy to continue discussing. 